### PR TITLE
Fix template path for blueprint

### DIFF
--- a/fees/app/__init__.py
+++ b/fees/app/__init__.py
@@ -1,10 +1,12 @@
 from flask import Flask
 from pathlib import Path
 
+
 def create_app():
-    # Determine templates folder (fees/fees/templates)
-    project_dir = Path(__file__).resolve().parents[2]
-    template_dir = project_dir / 'templates'
+    """Create and configure the Flask application."""
+    # Determine templates folder relative to this package (fees/templates)
+    project_dir = Path(__file__).resolve().parent.parent
+    template_dir = project_dir / "templates"
     app = Flask(__name__, template_folder=str(template_dir))
 
     with app.app_context():


### PR DESCRIPTION
## Summary
- ensure `create_app` points to package templates folder

## Testing
- `python -m pip install -r requirements.txt`
- `pytest -q` *(fails: command not found)*