### PR TITLE
Fix workbook processing on empty sheets

### DIFF
--- a/app/workbook_processor.py
+++ b/app/workbook_processor.py
@@ -17,9 +17,17 @@ def process_workbook(stream, week: int) -> BytesIO:
 
     # Read data into DataFrames
     df_cf = pd.DataFrame(cf.values)
+    df_rb = pd.DataFrame(rb.values)
+
+    # If either sheet is empty, return workbook unchanged
+    if df_cf.empty or df_rb.empty:
+        output = BytesIO()
+        wb.save(output)
+        output.seek(0)
+        return output
+
     df_cf.columns = df_cf.iloc[0]
     df_cf = df_cf[1:]
-    df_rb = pd.DataFrame(rb.values)
     df_rb.columns = df_rb.iloc[0]
     df_rb = df_rb[1:]
 

--- a/fees/app/workbook_processor.py
+++ b/fees/app/workbook_processor.py
@@ -14,9 +14,17 @@ def process_workbook(stream, week: int) -> BytesIO:
     rb = wb[f"Report Batch Week {week}"]
 
     df_cf = pd.DataFrame(cf.values)
+    df_rb = pd.DataFrame(rb.values)
+
+    # If either sheet is empty, return workbook unchanged
+    if df_cf.empty or df_rb.empty:
+        output = BytesIO()
+        wb.save(output)
+        output.seek(0)
+        return output
+
     df_cf.columns = df_cf.iloc[0]
     df_cf = df_cf[1:]
-    df_rb = pd.DataFrame(rb.values)
     df_rb.columns = df_rb.iloc[0]
     df_rb = df_rb[1:]
 


### PR DESCRIPTION
## Summary
- handle empty worksheets gracefully when processing

## Testing
- `python -m py_compile app/workbook_processor.py fees/app/workbook_processor.py`
- `python fees/tests/test_workbook_processor.py` *(fails: `ModuleNotFoundError: No module named 'pytest'`)*