### PR TITLE
Add drag-and-drop upload for query and report files

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -7,7 +7,7 @@
   <body>
     <h1>Weekly Cleanup & Setup</h1>
     <style>
-      #drop-area {
+      .drop-area {
         border: 2px dashed #ccc;
         border-radius: 10px;
         width: 100%;
@@ -17,48 +17,52 @@
         margin-bottom: 20px;
         cursor: pointer;
       }
-      #drop-area.highlight {
+      .drop-area.highlight {
         border-color: #666;
         background-color: #f8f8f8;
       }
-      #fileElem {
+      input[type=file] {
         display: none;
       }
     </style>
     <form method="post" enctype="multipart/form-data">
-      <div id="drop-area">
-        <p>Drag & drop your Excel/CSV file here, or click to select</p>
-        <input type="file" id="fileElem" name="workbook" accept=".xlsx,.csv" required>
+      <!-- Query file upload -->
+      <div id="drop-query" class="drop-area">
+        <p>Drag & drop the JNM - Cash Balance Data Comparison file here, or click to select</p>
+        <input type="file" id="queryElem" name="query_file" accept=".xlsx,.csv" required>
+      </div>
+      <!-- Report file upload -->
+      <div id="drop-report" class="drop-area">
+        <p>Drag & drop the SlickGridExport_JNM(#) file here, or click to select</p>
+        <input type="file" id="reportElem" name="report_file" accept=".xlsx,.csv" required>
       </div>
       <label>Week #: <input type="number" name="week" min="1" required></label><br><br>
       <button type="submit">Process</button>
     </form>
     <script>
-      const dropArea = document.getElementById('drop-area');
-      const fileInput = document.getElementById('fileElem');
-      const prompt = dropArea.querySelector('p');
-
-      ;['dragenter','dragover','dragleave','drop'].forEach(eventName => {
-        dropArea.addEventListener(eventName, e => { e.preventDefault(); e.stopPropagation(); }, false);
-      });
-      ;['dragenter','dragover'].forEach(eventName => {
-        dropArea.addEventListener(eventName, () => dropArea.classList.add('highlight'), false);
-      });
-      ;['dragleave','drop'].forEach(eventName => {
-        dropArea.addEventListener(eventName, () => dropArea.classList.remove('highlight'), false);
-      });
-      dropArea.addEventListener('drop', e => {
-        const dt = e.dataTransfer;
-        const files = dt.files;
-        if (files.length) {
-          fileInput.files = files;
-          prompt.textContent = files[0].name;
-        }
-      }, false);
-      dropArea.addEventListener('click', () => fileInput.click());
-      fileInput.addEventListener('change', () => {
-        if (fileInput.files.length) prompt.textContent = fileInput.files[0].name;
-      });
+      function setupDrop(areaId, inputId) {
+        const dropArea = document.getElementById(areaId);
+        const fileInput = document.getElementById(inputId);
+        const prompt = dropArea.querySelector('p');
+        ['dragenter','dragover','dragleave','drop'].forEach(evt => {
+          dropArea.addEventListener(evt, e => { e.preventDefault(); e.stopPropagation(); });
+        });
+        ['dragenter','dragover'].forEach(evt => dropArea.addEventListener(evt, () => dropArea.classList.add('highlight')));
+        ['dragleave','drop'].forEach(evt => dropArea.addEventListener(evt, () => dropArea.classList.remove('highlight')));
+        dropArea.addEventListener('drop', e => {
+          const files = e.dataTransfer.files;
+          if (files.length) {
+            fileInput.files = files;
+            prompt.textContent = files[0].name;
+          }
+        });
+        dropArea.addEventListener('click', () => fileInput.click());
+        fileInput.addEventListener('change', () => {
+          if (fileInput.files.length) prompt.textContent = fileInput.files[0].name;
+        });
+      }
+      setupDrop('drop-query','queryElem');
+      setupDrop('drop-report','reportElem');
     </script>
   </body>
 </html>


### PR DESCRIPTION
## Summary
- allow uploading separate query and report files via drag and drop
- save uploaded files under `Query/` and `Report/`
- process the uploaded query file

## Testing
- `python -m pytest -q` *(fails: No module named pytest)*